### PR TITLE
images: Fix linter warnings and errors

### DIFF
--- a/images/Dockerfile.ubuntu_focal
+++ b/images/Dockerfile.ubuntu_focal
@@ -31,8 +31,5 @@ ENV LC_ALL=C.UTF-8
 
 COPY --from=builder /usr/src/kubernetes-entrypoint/bin/kubernetes-entrypoint /usr/local/bin/kubernetes-entrypoint
 
-RUN apt update \
-    && apt install -y --no-install-recommends coreutils
-
 USER 65534
 ENTRYPOINT [ "/usr/local/bin/kubernetes-entrypoint" ]


### PR DESCRIPTION
Docker complains about mismatching case of `as` and `FROM`. ENV command needs to be of the format `ENV key=value`, leaving out the `=` is deprecated.

Change-Id: Ia25d3453d26d767938146ebc2068f90bc7deaaa0