### PR TITLE
images: Drop coreutils installation

### DIFF
--- a/images/Dockerfile.ubuntu_focal
+++ b/images/Dockerfile.ubuntu_focal
@@ -31,8 +31,5 @@ ENV LC_ALL=C.UTF-8
 
 COPY --from=builder /usr/src/kubernetes-entrypoint/bin/kubernetes-entrypoint /usr/local/bin/kubernetes-entrypoint
 
-RUN apt update \
-    && apt install -y --no-install-recommends coreutils
-
 USER 65534
 ENTRYPOINT [ "/usr/local/bin/kubernetes-entrypoint" ]


### PR DESCRIPTION
They are part of the base image (again?), and the apt install left 50MB worth of data in /var/lib/apt/lists around

Change-Id: I2bf1f3d971e84bd541081b3c82803deef0d2f87d