### PR TITLE
images: Add distroless_debian12

### DIFF
--- a/images/Dockerfile.distroless_debian12
+++ b/images/Dockerfile.distroless_debian12
@@ -1,0 +1,31 @@
+ARG FROM=gcr.io/distroless/static-debian12
+# Build the manager binary
+FROM golang:1.21 AS builder
+ARG TARGETOS
+ARG TARGETARCH
+
+SHELL [ "/bin/bash", "-cex" ]
+ADD . /usr/src/kubernetes-entrypoint
+WORKDIR /usr/src/kubernetes-entrypoint
+ENV GO111MODULE=on
+
+RUN make get-modules
+
+ARG MAKE_TARGET=build
+RUN make ${MAKE_TARGET}
+
+
+
+FROM ${FROM} AS release
+
+LABEL org.opencontainers.image.authors='airship-discuss@lists.airshipit.org, irc://#airshipit@freenode' \
+      org.opencontainers.image.url='https://airshipit.org' \
+      org.opencontainers.image.documentation='https://docs.airshipit.org/kubernetes-entrypoint' \
+      org.opencontainers.image.source='https://opendev.org/airship/kubernetes-entrypoint' \
+      org.opencontainers.image.vendor='The Airship Authors' \
+      org.opencontainers.image.licenses='Apache-2.0'
+
+COPY --from=builder /usr/src/kubernetes-entrypoint/bin/kubernetes-entrypoint /usr/local/bin/kubernetes-entrypoint
+
+USER 65534
+ENTRYPOINT [ "/usr/local/bin/kubernetes-entrypoint" ]


### PR DESCRIPTION
As go is compiled statically, it only needs some
static files from a distro, like certificates and timezones.

It will cut down the image size rougly in half, and more importantly removes unused binaries and libraries, which need to be maintained in case of security vulnerabilities.

See more under https://github.com/GoogleContainerTools/distroless

Change-Id: I924f703878520e4dd2a6bb455d9afd782d5beb2b